### PR TITLE
Fix form on mobile

### DIFF
--- a/timo_frontend/app/styles/app.scss
+++ b/timo_frontend/app/styles/app.scss
@@ -281,7 +281,8 @@ button {
 
   @include mobile {
     flex-direction: column;
-    display: flex
+    display: flex;
+    height: 100%;
   }
 }
 


### PR DESCRIPTION
Fix form style in modals for mobile. Buttons used to be at the center of page instead of at the bottom.